### PR TITLE
use parent package libgd-dev instead of libgd2-xpm-dev

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -32,7 +32,7 @@ apt-get install -y libxml2-dev     \
                 libpng12-dev    \
                 libxpm-dev      \
                 libfreetype6-dev        \
-                libgd2-xpm-dev  \
+                libgd-dev       \
                 libgmp-dev      \
                 libmhash-dev    \
                 unixodbc-dev    \


### PR DESCRIPTION
u16phpall [build](https://app.shippable.com/github/Shippable/jobs/php_x86_64_Ubuntu_16_04_prep/builds/5a3222b54cb6bc0700f62595/console) is failing saying it cannot resolve virtual package `libgd2-xpm-dev` which is installed [here](https://github.com/dry-dock/u16phpall/blob/master/install.sh#L35)


for ubuntu repo https://packages.ubuntu.com/search?keywords=libgd2-xpm-dev , it says its a virtual package provided by `libgd-dev`

debian package repo says, its a dummy package and can be remove when do other packages depend on it - https://packages.debian.org/sid/libgd2-xpm-dev

so instead we should install libgd-dev to fix the drydock image build. 